### PR TITLE
Exit the process when there are unreviewed diffs.

### DIFF
--- a/src/percy-node-client.js
+++ b/src/percy-node-client.js
@@ -305,12 +305,12 @@ async function checkBuildStatus(buildId, numRetries, resolve) {
   if (state == 'processing' || state == 'pending') {
       retry(buildId, numRetries, resolve);
   } else if (state == 'finished'){
-    const totalDiffs = attributes['total-comparisons-diff'];
-      if (totalDiffs) {
+    const totalUnreviewed = attributes['total-snapshots-unreviewed'];
+      if (totalUnreviewed) {
         const url = attributes['web-url'];
-        handleError('percy', `diffs found: ${totalDiffs}. Check ${url}`);
+        handleError('percy', `unreviewed diffs found: ${totalUnreviewed}. Check ${url}`);
       } else {
-        logger.log('Hooray! The build is successful with no diffs. \\o/');
+        logger.log('Hooray! The build is successful with no unreviewed diffs. \\o/');
       }
       resolve();
   } else if (state == 'failed') {

--- a/src/percy-node-client.js
+++ b/src/percy-node-client.js
@@ -305,6 +305,7 @@ async function checkBuildStatus(buildId, numRetries, resolve) {
   if (state == 'processing' || state == 'pending') {
       retry(buildId, numRetries, resolve);
   } else if (state == 'finished'){
+    // Unreviewed diffs are the diffs which have not been approved in the percy UI
     const totalUnreviewed = attributes['total-snapshots-unreviewed'];
       if (totalUnreviewed) {
         const url = attributes['web-url'];


### PR DESCRIPTION
We found out those new screenshots are not turned into Golden files on Percy until those changes are submitted to master. Approving diffs on Percy just pre-approves it, which does not change the value of 
"total-comparisons-diff".  The correct attribute to track the build status is "total-snapshots-unreviewed". When it is 0, it means there is no diffs or all diffs have been approved.